### PR TITLE
feat: Adapt database schema and add initial payment provider logic

### DIFF
--- a/my-app/package.json
+++ b/my-app/package.json
@@ -9,9 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@supabase/auth-helpers-nextjs": "^0.8.7", // Choose latest compatible version
-    "@supabase/supabase-js": "^2.39.3", // Choose latest compatible version
-    "next": "14.1.0", // Or your specific Next.js version
+    "@supabase/auth-helpers-nextjs": "^0.8.7",
+    "@supabase/supabase-js": "^2.39.3",
+    "next": "14.1.0",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/my-app/src/app/api/stripe/webhook/route.ts
+++ b/my-app/src/app/api/stripe/webhook/route.ts
@@ -1,0 +1,282 @@
+import { NextResponse } from 'next/server'
+import Stripe from 'stripe'
+import { headers } from 'next/headers'
+import { createClient } from '@supabase/supabase-js' // Usar createClient directamente para webhooks
+
+// Inicializar Stripe con la clave secreta
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+  apiVersion: '2024-04-10', // Asegúrate que coincida con la de create-checkout-session
+  typescript: true,
+})
+
+// Clave secreta del endpoint de webhook de Stripe (¡MUY IMPORTANTE!)
+// Deberás obtenerla desde tu Dashboard de Stripe al configurar el endpoint del webhook.
+// Guárdala en tus variables de entorno.
+const stripeWebhookSecret = process.env.STRIPE_WEBHOOK_SECRET || ''
+
+// Inicializar el cliente de Supabase para operaciones de backend
+// Estas variables deben estar en el entorno donde se ejecuta esta función (ej. Vercel, Supabase Edge Functions)
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '' // ¡Usa la service_role key aquí!
+
+if (!supabaseServiceRoleKey) {
+    console.error('SUPABASE_SERVICE_ROLE_KEY is not set. Webhook handler cannot operate securely.');
+}
+// Es importante usar la service_role key para operaciones de backend que modifican datos
+// y necesitan saltarse las políticas RLS. Asegúrate de que esta variable esté disponible
+// en el entorno de despliegue de esta función.
+const supabaseAdmin = createClient(supabaseUrl, supabaseServiceRoleKey)
+
+
+export async function POST(request: Request) {
+  const body = await request.text()
+  const signature = headers().get('stripe-signature')
+
+  if (!signature) {
+    console.error('Webhook error: Missing Stripe signature.')
+    return NextResponse.json({ error: 'Missing Stripe signature' }, { status: 400 })
+  }
+
+  if (!stripeWebhookSecret) {
+    console.error('Webhook error: Stripe Webhook Secret is not configured.')
+    return NextResponse.json({ error: 'Webhook configuration error' }, { status: 500 })
+  }
+
+  let event: Stripe.Event
+  try {
+    event = stripe.webhooks.constructEvent(body, signature, stripeWebhookSecret)
+  } catch (err: any) {
+    console.error(`Webhook signature verification failed: ${err.message}`)
+    return NextResponse.json({ error: `Webhook error: ${err.message}` }, { status: 400 })
+  }
+
+  // Manejar el evento
+  // Referencia de tipos de evento: https://stripe.com/docs/api/events/types
+  try {
+    switch (event.type) {
+      case 'customer.subscription.created':
+      case 'customer.subscription.updated':
+      case 'customer.subscription.deleted': // También maneja cancelaciones, fin de pruebas, etc.
+        const subscription = event.data.object as Stripe.Subscription
+        await handleSubscriptionChange(subscription)
+        break
+
+      case 'checkout.session.completed':
+        const session = event.data.object as Stripe.Checkout.Session
+        // Este evento es crucial. Aquí es donde normalmente crearías/actualizarías
+        // la suscripción en tu base de datos por primera vez.
+        await handleCheckoutSessionCompleted(session)
+        break
+
+      // case 'invoice.payment_succeeded':
+      //   const invoice = event.data.object as Stripe.Invoice;
+      //   // Usado para cuando una suscripción se renueva exitosamente.
+      //   // Podrías actualizar current_period_start y current_period_end aquí si es necesario,
+      //   // aunque customer.subscription.updated también suele cubrir esto.
+      //   if (invoice.subscription && invoice.billing_reason === 'subscription_cycle') {
+      //       const subscriptionId = typeof invoice.subscription === 'string' ? invoice.subscription : invoice.subscription.id;
+      //       const stripeSubscription = await stripe.subscriptions.retrieve(subscriptionId);
+      //       await handleSubscriptionChange(stripeSubscription);
+      //   }
+      //   break;
+
+      // case 'invoice.payment_failed':
+      //   // El pago de una factura de suscripción falló.
+      //   // customer.subscription.updated con status 'past_due' o 'unpaid' también se dispara.
+      //   // Puedes manejar notificaciones al usuario aquí.
+      //   break;
+
+      default:
+        console.log(`Unhandled Stripe webhook event type: ${event.type}`)
+    }
+  } catch (error: any) {
+      console.error(`Error handling webhook event ${event.type}:`, error.message)
+      // Devolver un error 500 podría hacer que Stripe reintente el webhook si es apropiado.
+      // Si el error es debido a un problema de nuestra lógica que no se resolverá con un reintento,
+      // podríamos considerar devolver un 200 para evitar reintentos infinitos para ese evento específico.
+      // Por ahora, devolvemos 500 para indicar un problema en nuestro lado.
+      return NextResponse.json({ error: 'Webhook handler failed. Please check logs.' }, { status: 500 })
+  }
+
+  return NextResponse.json({ received: true })
+}
+
+
+async function handleSubscriptionChange(subscription: Stripe.Subscription) {
+  const { id: stripe_subscription_id, customer, status, current_period_start, current_period_end, cancel_at_period_end, canceled_at, ended_at, trial_start, trial_end } = subscription
+  const stripe_customer_id = typeof customer === 'string' ? customer : customer.id
+
+  // Obtener el user_id de tus metadatos o de tu tabla de clientes/perfiles
+  // Esto asume que guardaste userId en los metadatos del cliente de Stripe o tienes una tabla que mapea stripe_customer_id a user_id.
+  // Si está en los metadatos del cliente de Stripe:
+  const stripeCustomer = await stripe.customers.retrieve(stripe_customer_id) as Stripe.Customer;
+  const userId = stripeCustomer.metadata?.userId;
+
+  if (!userId) {
+      console.error(`Webhook Error: No userId found in Stripe customer metadata for customer ${stripe_customer_id}. Cannot update subscription.`);
+      // Podrías decidir lanzar un error aquí o simplemente loguearlo.
+      // Si no puedes asociar la suscripción a un usuario, no puedes actualizar tu DB.
+      return;
+  }
+
+  // Obtener el plan_id de tu tabla 'plans' usando el price ID de la suscripción
+  // Stripe Subscription object tiene items.data[0].price.id
+  const priceId = subscription.items.data[0]?.price.id
+  let planId = null
+
+  if (priceId) {
+    const { data: planData, error: planError } = await supabaseAdmin
+      .from('plans')
+      .select('id')
+      .eq('stripe_price_id', priceId)
+      .single()
+
+    if (planError) {
+      console.error(`Webhook Error: Could not find plan with stripe_price_id ${priceId}:`, planError.message)
+      // Decide cómo manejar esto. ¿Continuar sin plan_id? ¿Error?
+    } else {
+      planId = planData.id
+    }
+  } else {
+      console.warn(`Webhook Warning: Subscription ${stripe_subscription_id} has no price ID. Cannot determine plan_id.`);
+  }
+
+
+  const subscriptionDataForDb = {
+    user_id: userId,
+    plan_id: planId, // Puede ser null si no se encontró o no hay priceId
+    stripe_subscription_id,
+    stripe_customer_id,
+    status,
+    current_period_start: new Date(current_period_start * 1000).toISOString(),
+    current_period_end: new Date(current_period_end * 1000).toISOString(),
+    cancel_at_period_end: cancel_at_period_end || false,
+    canceled_at: canceled_at ? new Date(canceled_at * 1000).toISOString() : null,
+    ended_at: ended_at ? new Date(ended_at * 1000).toISOString() : null,
+    trial_start: trial_start ? new Date(trial_start * 1000).toISOString() : null,
+    trial_end: trial_end ? new Date(trial_end * 1000).toISOString() : null,
+  }
+
+  // Upsert en la tabla de suscripciones
+  const { error: upsertError } = await supabaseAdmin
+    .from('subscriptions')
+    .upsert(subscriptionDataForDb, { onConflict: 'stripe_subscription_id' })
+
+  if (upsertError) {
+    console.error(`Webhook Error: Failed to upsert subscription ${stripe_subscription_id} for user ${userId}:`, upsertError.message)
+    throw new Error(`Failed to upsert subscription: ${upsertError.message}`);
+  } else {
+    console.log(`Subscription ${status} for ${stripe_subscription_id} (user ${userId}) processed successfully.`)
+    // Aquí también podrías actualizar el rol del usuario si tienes una columna de rol
+    // basada en el estado de la suscripción y el plan.
+  }
+}
+
+
+async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Session) {
+    const stripe_subscription_id = session.subscription
+    const stripe_customer_id = session.customer
+    const userId = session.metadata?.userId
+
+    if (!userId) {
+        console.error('Webhook Error: checkout.session.completed missing userId in metadata. Session ID:', session.id)
+        return; // No se puede procesar sin userId
+    }
+
+    if (!stripe_subscription_id || typeof stripe_subscription_id !== 'string') {
+        console.error('Webhook Error: checkout.session.completed missing or invalid subscription ID. Session ID:', session.id)
+        // Esto puede ocurrir para pagos únicos, pero este manejador es para suscripciones.
+        return;
+    }
+
+    if (!stripe_customer_id || typeof stripe_customer_id !== 'string') {
+        console.error('Webhook Error: checkout.session.completed missing or invalid customer ID. Session ID:', session.id)
+        return;
+    }
+
+    // Recuperar los detalles completos de la suscripción desde Stripe, ya que la sesión no los tiene todos.
+    const subscription = await stripe.subscriptions.retrieve(stripe_subscription_id as string)
+
+    // Ahora tenemos el objeto de suscripción completo, podemos usar la misma lógica que handleSubscriptionChange.
+    // Esto asegura que todos los campos relevantes (como plan_id, period_end, etc.) se establezcan correctamente.
+    await handleSubscriptionChange(subscription);
+
+    // Opcional: Si no guardaste el stripe_customer_id cuando se creó en create-checkout-session,
+    // este es un buen lugar para asegurarte de que esté asociado a tu usuario en una tabla de perfiles.
+    // Ejemplo:
+    // const { error: profileError } = await supabaseAdmin
+    //   .from('user_profiles') // Asumiendo que tienes una tabla user_profiles
+    //   .upsert({ user_id: userId, stripe_customer_id: stripe_customer_id }, { onConflict: 'user_id' });
+    // if (profileError) {
+    //   console.error(`Webhook Error: Failed to update profile with stripe_customer_id ${stripe_customer_id} for user ${userId}:`, profileError.message);
+    // }
+
+    console.log(`Checkout session ${session.id} completed for user ${userId}, subscription ${stripe_subscription_id}.`)
+}
+
+
+// Notas importantes sobre este manejador de webhooks:
+// 1. Seguridad del Webhook Secret: `STRIPE_WEBHOOK_SECRET` es VITAL. Sin él, cualquiera podría enviar datos falsos a tu endpoint.
+//    Obtenlo de tu Stripe Dashboard cuando configures el endpoint del webhook.
+//    Asegúrate de que esta variable de entorno esté disponible donde se despliega esta función.
+//
+// 2. Supabase Service Role Key: Para operaciones de backend como esta, que necesitan modificar datos
+//    potencialmente saltándose RLS (o con permisos elevados), debes usar la `service_role` key de Supabase.
+//    NO uses la `anon` key aquí. `SUPABASE_SERVICE_ROLE_KEY` debe estar en tus variables de entorno del servidor.
+//
+// 3. Idempotencia: Los webhooks pueden ser enviados por Stripe múltiples veces (por ejemplo, si tu endpoint no responde
+//    rápidamente con un 2xx o si hay problemas de red). Tu lógica para manejar eventos debe ser idempotente,
+//    lo que significa que procesar el mismo evento múltiples veces no debería causar efectos secundarios no deseados
+//    (como crear múltiples suscripciones para el mismo evento). El `upsert` con `onConflict` ayuda con esto.
+//
+// 4. Mapeo de `stripe_customer_id` a `user_id`: Es crucial poder mapear el `stripe_customer_id` (o la suscripción)
+//    de vuelta a tu `user_id` interno. La forma más común es guardar el `userId` en los metadatos del objeto Customer
+//    o Subscription de Stripe cuando se crean, y luego recuperarlo aquí. El ejemplo asume `userId` en `customer.metadata.userId`.
+//
+// 5. Mapeo de `price_id` a `plan_id`: Para asociar la suscripción de Stripe con tu tabla `plans` interna,
+//    necesitas buscar el `plan_id` basado en el `price.id` que viene en el objeto de suscripción de Stripe.
+//
+// 6. Manejo de Errores y Logging: El logging aquí es básico. En producción, querrás un logging más estructurado y
+//    posiblemente un sistema de alertas para fallos en el procesamiento de webhooks.
+//
+// 7. Tipos de Eventos: Solo se manejan algunos eventos comunes. Revisa la lista de eventos de Stripe
+//    (https://stripe.com/docs/api/events/types) y decide cuáles son relevantes para tu lógica de negocio.
+//    Por ejemplo, `invoice.payment_succeeded`, `invoice.payment_failed`, `customer.subscription.trial_will_end`.
+//
+// 8. Pruebas: Usa la CLI de Stripe ( `stripe listen --forward-to localhost:3000/api/stripe/webhook` ) para probar
+//    tus webhooks localmente durante el desarrollo. Stripe también te permite enviar eventos de prueba desde el Dashboard.
+//
+// 9. Variables de Entorno Faltantes: El código incluye comprobaciones para `stripeWebhookSecret` y `supabaseServiceRoleKey`.
+//    Si no están configuradas, el webhook no funcionará correctamente o de forma segura.
+//
+// Este endpoint debe ser configurado en tu Dashboard de Stripe:
+// Developers > Webhooks > Add endpoint.
+// URL del endpoint: https://<tu-dominio-o-url-de-vercel>/api/stripe/webhook
+// Eventos a escuchar: Como mínimo `checkout.session.completed`, `customer.subscription.created`, `customer.subscription.updated`, `customer.subscription.deleted`.
+// Considera añadir también eventos de facturas (`invoice.payment_succeeded`, `invoice.payment_failed`).
+//
+// Este archivo debe estar en `my-app/src/app/api/stripe/webhook/route.ts`
+//
+// La función `handleSubscriptionChange` se ha hecho genérica para ser usada por múltiples eventos de suscripción.
+// La función `handleCheckoutSessionCompleted` es específica para cuando el checkout se completa,
+// y luego llama a `handleSubscriptionChange` para la lógica de upsert de la suscripción.
+//
+// Recuerda que la `service_role` key de Supabase tiene permisos de administrador sobre tu base de datos,
+// así que mantenla SECRETA y úsala solo en entornos de backend seguros.
+// No la expongas en el lado del cliente ni en tu código fuente público.
+//
+// El `console.error` para `SUPABASE_SERVICE_ROLE_KEY` no configurada es importante.
+// Sin esta clave, las operaciones de base de datos probablemente fallarán o no tendrán los permisos correctos.
+//
+// Es importante que el `stripe_customer_id` se asocie correctamente al `user_id`.
+// Si creas el `stripe.customers.create` en `create-checkout-session` y guardas el `userId` en `metadata`,
+// entonces en el webhook `checkout.session.completed`, el objeto `session.customer` (que es el ID del cliente)
+// te permitirá recuperar ese cliente de Stripe y sus metadatos para obtener tu `userId` interno.
+// El ejemplo actual lo hace en `handleSubscriptionChange` recuperando el cliente de Stripe.
+//
+// Si `planId` no se encuentra (porque el `stripe_price_id` en la suscripción no coincide con ninguno en tu tabla `plans`),
+// la columna `plan_id` en la tabla `subscriptions` será `NULL`. Deberás decidir cómo manejar esta situación.
+// Podría indicar un desajuste de configuración entre Stripe y tu base de datos.
+//
+// La conversión de timestamps de Stripe (que están en segundos desde la época Unix) a cadenas ISO
+// se hace con `new Date(timestamp * 1000).toISOString()`.

--- a/my-app/src/app/globals.css
+++ b/my-app/src/app/globals.css
@@ -3,8 +3,60 @@
 @tailwind utilities;
 
 body {
-  /* You can add default body styles here if needed, beyond Tailwind's preflight */
-  /* For example, ensure text is anti-aliased for better readability */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #0D0D0D; /* Similar to n8n's dark background */
+  color: #E0E0E0; /* Light gray text for contrast, similar to n8n */
+}
+
+/* Define a custom font class if you want to use a specific font like n8n */
+.font-custom {
+  font-family: 'Inter', sans-serif; /* Assuming Inter is the desired font, similar to n8n. Make sure to import it in layout.tsx */
+}
+
+/* Example of how you might style links to match n8n's aesthetic */
+a {
+  color: #569CD6; /* A blue often used in sober/dark themes for links */
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* Basic button styling to align with a sober theme */
+button, .button {
+  background-color: #333333; /* Darker gray for buttons */
+  color: #FFFFFF;
+  padding: 10px 20px;
+  border-radius: 5px;
+  border: 1px solid #444444; /* Subtle border */
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+button:hover, .button:hover {
+  background-color: #454545; /* Slightly lighter on hover */
+}
+
+/* Input fields styling */
+input[type="text"],
+input[type="email"],
+input[type="password"],
+textarea {
+  background-color: #1A1A1A;
+  color: #E0E0E0;
+  border: 1px solid #333333;
+  padding: 10px;
+  border-radius: 5px;
+  width: 100%; /* Default to full width */
+}
+
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="password"]:focus,
+textarea:focus {
+  outline: none;
+  border-color: #569CD6; /* Highlight focus with the link color */
+  box-shadow: 0 0 0 2px rgba(86, 156, 214, 0.5); /* Optional: add a subtle glow */
 }

--- a/my-app/src/app/ia-analysis/page.tsx
+++ b/my-app/src/app/ia-analysis/page.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { useState, FormEvent } from 'react'
+
+// Tipos para la respuesta del análisis de IA
+interface AnalysisDetail {
+  impact: string
+  news: string
+  reason: string
+  horizon: string
+}
+
+interface Forecast {
+  [assetName: string]: AnalysisDetail
+}
+
+interface AnalysisResponse {
+  forecast: Forecast
+}
+
+export default function IaAnalysisPage() {
+  const [assetsInput, setAssetsInput] = useState('')
+  const [analysisResult, setAnalysisResult] = useState<AnalysisResponse[] | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setIsLoading(true)
+    setError(null)
+    setAnalysisResult(null)
+
+    const assetsToAnalyze = assetsInput.split(',').map(asset => asset.trim()).filter(asset => asset.length > 0)
+
+    if (assetsToAnalyze.length === 0) {
+      setError('Please enter at least one asset to analyze.')
+      setIsLoading(false)
+      return
+    }
+
+    // TODO: Reemplazar con datos de usuario reales cuando el sistema de autenticación/suscripción esté listo
+    const requestBody = {
+      userData: {
+        userId: 'test-user-123', // Ejemplo
+        tier: 'premium', // Asumimos premium para acceso completo por ahora
+      },
+      assetsToAnalyze: assetsToAnalyze,
+    }
+
+    try {
+      const response = await fetch('http://localhost:5678/webhook-test/88371509-3d66-45d6-9482-5999eb94bc42', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json()
+        throw new Error(errorData.message || `HTTP error! status: ${response.status}`)
+      }
+
+      const data: AnalysisResponse[] = await response.json()
+      setAnalysisResult(data)
+    } catch (err: any) {
+      setError(err.message || 'Failed to fetch analysis. Make sure your n8n webhook is running and accessible.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-n8n-dark text-n8n-text-primary font-sans p-4 md:p-8">
+      <div className="max-w-3xl mx-auto bg-n8n-surface p-6 md:p-8 rounded-lg shadow-xl">
+        <h1 className="text-3xl font-bold text-n8n-accent mb-6 text-center">AI Financial Analysis</h1>
+
+        <form onSubmit={handleSubmit} className="space-y-6 mb-8">
+          <div>
+            <label htmlFor="assets" className="block text-sm font-medium text-n8n-text-secondary mb-1">
+              Assets to Analyze (comma-separated)
+            </label>
+            <input
+              id="assets"
+              name="assets"
+              type="text"
+              value={assetsInput}
+              onChange={(e) => setAssetsInput(e.target.value)}
+              className="mt-1 block w-full px-3 py-2 bg-n8n-dark border border-n8n-border rounded-md shadow-sm placeholder-n8n-text-secondary focus:outline-none focus:ring-n8n-accent focus:border-n8n-accent sm:text-sm text-n8n-text-primary"
+              placeholder="e.g., NASDAQ:AAPL, US_Employment_Market, BTC-USD"
+              required
+            />
+            <p className="mt-1 text-xs text-n8n-text-secondary">Enter asset symbols or economic indicators.</p>
+          </div>
+          <div>
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="w-full flex justify-center py-2.5 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-n8n-accent hover:bg-n8n-accent-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-n8n-surface focus:ring-n8n-accent disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {isLoading ? 'Analyzing...' : 'Get Analysis'}
+            </button>
+          </div>
+        </form>
+
+        {error && (
+          <div className="bg-n8n-error/20 border border-n8n-error text-n8n-error px-4 py-3 rounded-md mb-6" role="alert">
+            <strong className="font-bold">Error: </strong>
+            <span className="block sm:inline">{error}</span>
+          </div>
+        )}
+
+        {analysisResult && analysisResult.length > 0 && (
+          <div className="space-y-6">
+            <h2 className="text-2xl font-semibold text-n8n-accent mb-4">Analysis Results</h2>
+            {analysisResult.map((resultItem, index) => (
+              <div key={index} className="bg-n8n-dark p-4 rounded-md shadow-lg">
+                {Object.entries(resultItem.forecast).map(([assetName, details]) => (
+                  <div key={assetName} className="mb-6 pb-6 border-b border-n8n-border last:border-b-0 last:mb-0 last:pb-0">
+                    <h3 className="text-xl font-semibold text-n8n-accent-hover mb-2">{assetName}</h3>
+                    <p className={`text-lg font-medium ${details.impact === 'negative' ? 'text-n8n-error' : details.impact === 'positive' ? 'text-n8n-success' : 'text-n8n-text-primary'}`}>
+                      Impact: <span className="font-bold">{details.impact}</span>
+                    </p>
+                    <p className="text-sm text-n8n-text-secondary mt-1">Horizon: {details.horizon}</p>
+                    <div className="mt-3 bg-n8n-surface p-3 rounded">
+                       <p className="text-md text-n8n-text-primary mb-1"> <span className="font-semibold">News:</span> {details.news}</p>
+                       <p className="text-md text-n8n-text-primary"> <span className="font-semibold">Reason:</span> {details.reason}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+         {analysisResult && analysisResult.length === 0 && !isLoading && (
+          <div className="text-center text-n8n-text-secondary py-4">
+            No analysis results to display.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/my-app/src/app/layout.tsx
+++ b/my-app/src/app/layout.tsx
@@ -2,11 +2,14 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css"; // Ensure this is correctly imported
 
-const inter = Inter({ subsets: ["latin"] });
+const inter = Inter({
+  subsets: ["latin"],
+  variable: '--font-inter', // Define a CSS variable for Inter font
+});
 
 export const metadata: Metadata = {
-  title: "Financial Tracker", // Updated title
-  description: "Track your financial assets and market news.", // Updated description
+  title: "Financial Insight Engine", // Updated title to reflect AI and financial focus
+  description: "AI-powered financial asset analysis and market insights.", // Updated description
 };
 
 export default function RootLayout({
@@ -15,9 +18,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      {/* Added a dark theme to the body for overall modern look */}
-      <body className={`${inter.className} bg-gray-900 text-white`}>{children}</body>
+    <html lang="en" className={inter.variable}> {/* Apply Inter font variable to html tag */}
+      {/* Body will inherit styles from globals.css, including background and text color */}
+      <body>{children}</body>
     </html>
   );
 }

--- a/my-app/src/app/login/page.tsx
+++ b/my-app/src/app/login/page.tsx
@@ -49,12 +49,12 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-900 text-white">
-      <div className="w-full max-w-md p-8 space-y-6 bg-gray-800 rounded-lg shadow-lg">
-        <h1 className="text-3xl font-bold text-center text-sky-400">Sign In</h1>
+    <div className="flex min-h-screen flex-col items-center justify-center bg-n8n-dark font-sans">
+      <div className="w-full max-w-md p-8 space-y-6 bg-n8n-surface rounded-lg shadow-xl">
+        <h1 className="text-3xl font-bold text-center text-n8n-accent">Sign In</h1>
         <form onSubmit={handleSignIn} className="space-y-6">
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-300">
+            <label htmlFor="email" className="block text-sm font-medium text-n8n-text-secondary">
               Email address
             </label>
             <input
@@ -65,13 +65,13 @@ export default function LoginPage() {
               required
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-sky-500 focus:border-sky-500 sm:text-sm"
+              className="mt-1 block w-full px-3 py-2 bg-n8n-dark border border-n8n-border rounded-md shadow-sm placeholder-n8n-text-secondary focus:outline-none focus:ring-n8n-accent focus:border-n8n-accent sm:text-sm text-n8n-text-primary"
               placeholder="you@example.com"
             />
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-300">
+            <label htmlFor="password" className="block text-sm font-medium text-n8n-text-secondary">
               Password
             </label>
             <input
@@ -82,47 +82,46 @@ export default function LoginPage() {
               required
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-sky-500 focus:border-sky-500 sm:text-sm"
+              className="mt-1 block w-full px-3 py-2 bg-n8n-dark border border-n8n-border rounded-md shadow-sm placeholder-n8n-text-secondary focus:outline-none focus:ring-n8n-accent focus:border-n8n-accent sm:text-sm text-n8n-text-primary"
               placeholder="••••••••"
             />
           </div>
 
-          {error && <p className="text-sm text-red-400">{error}</p>}
+          {error && <p className="text-sm text-n8n-error">{error}</p>}
 
           <div>
             <button
               type="submit"
               disabled={isSubmitting}
-              className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-sky-600 hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-sky-500 disabled:opacity-50"
+              className="w-full flex justify-center py-2.5 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-n8n-accent hover:bg-n8n-accent-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-n8n-surface focus:ring-n8n-accent disabled:opacity-60 disabled:cursor-not-allowed"
             >
               {isSubmitting ? 'Signing In...' : 'Sign In'}
             </button>
           </div>
         </form>
-        <div className="relative my-4">
+        <div className="relative my-6">
           <div className="absolute inset-0 flex items-center">
-            <div className="w-full border-t border-gray-600" />
+            <div className="w-full border-t border-n8n-border" />
           </div>
           <div className="relative flex justify-center text-sm">
-            <span className="px-2 bg-gray-800 text-gray-400">Or continue with</span>
+            <span className="px-3 bg-n8n-surface text-n8n-text-secondary">Or continue with</span>
           </div>
         </div>
         <div>
           <button
             onClick={handleGitHubSignIn}
             disabled={isSubmitting}
-            className="w-full flex items-center justify-center py-2 px-4 border border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-300 bg-gray-700 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-sky-500 disabled:opacity-50"
+            className="w-full flex items-center justify-center py-2.5 px-4 border border-n8n-border rounded-md shadow-sm text-sm font-medium text-n8n-text-primary bg-n8n-button hover:bg-n8n-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-n8n-surface focus:ring-n8n-accent disabled:opacity-60 disabled:cursor-not-allowed"
           >
-            {/* Simple GitHub icon placeholder, replace with actual SVG if desired */}
             <svg className="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
               <path fillRule="evenodd" d="M10 0C4.477 0 0 4.477 0 10c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.483 0-.237-.009-.868-.013-1.703-2.782.602-3.369-1.343-3.369-1.343-.455-1.158-1.11-1.465-1.11-1.465-.909-.62.069-.608.069-.608 1.004.074 1.532 1.03 1.532 1.03.891 1.529 2.341 1.087 2.91.832.091-.647.349-1.086.635-1.337-2.22-.251-4.555-1.111-4.555-4.943 0-1.091.39-1.984 1.03-2.682-.103-.252-.447-1.27.098-2.646 0 0 .84-.269 2.75 1.025A9.548 9.548 0 0110 5.425c.854 0 1.708.115 2.504.336 1.909-1.294 2.748-1.025 2.748-1.025.547 1.376.203 2.394.1 2.646.64.698 1.027 1.59 1.027 2.682 0 3.842-2.338 4.687-4.565 4.935.358.307.679.917.679 1.85 0 1.333-.012 2.407-.012 2.734 0 .268.18.578.688.48C17.138 18.163 20 14.417 20 10c0-5.523-4.477-10-10-10z" clipRule="evenodd" />
             </svg>
             Sign In with GitHub
           </button>
         </div>
-        <p className="mt-6 text-center text-sm text-gray-400">
+        <p className="mt-8 text-center text-sm text-n8n-text-secondary">
           Don&apos;t have an account?{' '}
-          <a href="/signup" className="font-medium text-sky-400 hover:text-sky-300">
+          <a href="/signup" className="font-medium text-n8n-accent hover:text-n8n-accent-hover">
             Sign Up
           </a>
         </p>

--- a/my-app/src/app/pricing/page.tsx
+++ b/my-app/src/app/pricing/page.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import type { Database } from '@/lib/database.types' // Asegúrate que esta ruta sea correcta
+
+// Definición del tipo Plan (debe coincidir con tu tabla 'plans')
+export interface Plan {
+  id: string
+  name: string
+  price: number
+  currency: string
+  interval: string | null
+  features: string[] // Asumiendo que 'features' es un JSON array de strings
+  stripe_price_id: string | null
+  active: boolean
+  description: string | null
+}
+
+export default function PricingPage() {
+  const [plans, setPlans] = useState<Plan[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const supabase = createClientComponentClient<Database>()
+
+  useEffect(() => {
+    const fetchPlans = async () => {
+      setIsLoading(true)
+      setError(null)
+
+      const { data, error } = await supabase
+        .from('plans')
+        .select('*')
+        .eq('active', true) // Solo obtener planes activos
+        .order('price', { ascending: true }) // Ordenar por precio
+
+      if (error) {
+        console.error('Error fetching plans:', error)
+        setError('Could not fetch pricing plans. Please try again later.')
+      } else {
+        // Asegurarse de que 'features' sea un array. Si es un string JSON, parsearlo.
+        const formattedPlans = data.map(plan => ({
+          ...plan,
+          features: typeof plan.features === 'string' ? JSON.parse(plan.features) : plan.features || [],
+        }))
+        setPlans(formattedPlans)
+      }
+      setIsLoading(false)
+    }
+
+    fetchPlans()
+  }, [supabase])
+
+  const handleSubscribe = async (plan: Plan) => {
+    if (!plan.stripe_price_id) {
+      alert('Este plan no está configurado para suscripción online.')
+      return
+    }
+    // TODO: Implementar la lógica para redirigir al Checkout de Stripe
+    // Esto implicará llamar a un endpoint en nuestro backend que cree la sesión de Stripe.
+    alert(`Redirigiendo a Stripe para el plan: ${plan.name} con ID: ${plan.stripe_price_id}`)
+    // TODO: Implementar la lógica para redirigir al Checkout de Stripe
+    // Esto implicará llamar a un endpoint en nuestro backend que cree la sesión de Stripe.
+    // alert(`Redirigiendo a Stripe para el plan: ${plan.name} con ID: ${plan.stripe_price_id}`)
+    console.log('Attempting to subscribe to plan:', plan.stripe_price_id)
+    setIsLoading(true) // Indicar carga durante la llamada a la API
+    setError(null)
+
+    try {
+      const response = await fetch('/api/stripe/create-checkout-session', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ priceId: plan.stripe_price_id }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || `Failed to create checkout session. Status: ${response.status}`);
+      }
+
+      const sessionData = await response.json();
+
+      if (sessionData.sessionUrl) {
+        // Redirigir al usuario a la página de checkout de Stripe
+        window.location.href = sessionData.sessionUrl;
+      } else if (sessionData.sessionId) {
+        // Si solo se devuelve sessionId, necesitarías Stripe.js para redirigir
+        // Esto es un fallback, idealmente sessionUrl siempre debería estar presente
+        alert('Checkout session created. Please implement Stripe.js redirection or ensure sessionUrl is returned.');
+        console.log('Checkout Session ID:', sessionData.sessionId);
+      } else {
+        throw new Error('Invalid session data received from server.');
+      }
+
+    } catch (err: any) {
+      console.error('Subscription error:', err);
+      setError(err.message || 'Could not initiate subscription. Please try again.');
+      setIsLoading(false); // Detener la carga en caso de error
+    }
+    // No establecer setIsLoading(false) aquí si la redirección es exitosa, ya que la página cambiará.
+  }
+
+  if (isLoading && plans.length === 0) { // Mostrar loading solo si los planes aún no se han cargado
+    return (
+      <div className="min-h-screen bg-n8n-dark text-n8n-text-primary flex justify-center items-center">
+        <p className="text-xl">Loading pricing plans...</p>
+        {/* Podrías añadir un spinner aquí */}
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-n8n-dark text-n8n-text-primary flex flex-col justify-center items-center p-8">
+        <div className="bg-n8n-error/20 border border-n8n-error text-n8n-error px-6 py-4 rounded-md text-center">
+          <h2 className="text-2xl font-bold mb-2">Error</h2>
+          <p>{error}</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-n8n-dark text-n8n-text-primary font-sans p-4 md:p-8">
+      <div className="max-w-5xl mx-auto">
+        <h1 className="text-4xl font-bold text-n8n-accent mb-10 text-center">
+          Choose Your Plan
+        </h1>
+
+        {plans.length === 0 && !isLoading && (
+          <p className="text-center text-n8n-text-secondary">No active plans available at the moment.</p>
+        )}
+
+        <div className="grid md:grid-cols-3 gap-8">
+          {plans.map((plan) => (
+            <div
+              key={plan.id}
+              className="bg-n8n-surface rounded-lg shadow-xl p-6 flex flex-col"
+            >
+              <h2 className="text-2xl font-semibold text-n8n-accent-hover mb-3">{plan.name}</h2>
+              {plan.description && (
+                <p className="text-sm text-n8n-text-secondary mb-4">{plan.description}</p>
+              )}
+              <div className="mb-5">
+                <span className="text-4xl font-extrabold text-white">
+                  ${plan.price.toFixed(2)}
+                </span>
+                <span className="text-n8n-text-secondary ml-1">
+                  {plan.interval ? `/ ${plan.interval}` : ''}
+                </span>
+              </div>
+              <ul className="space-y-2 mb-6 text-n8n-text-primary flex-grow">
+                {plan.features && plan.features.map((feature, index) => (
+                  <li key={index} className="flex items-center">
+                    <svg className="w-5 h-5 text-n8n-success mr-2 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                      <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                    </svg>
+                    {feature}
+                  </li>
+                ))}
+              </ul>
+              <button
+                onClick={() => handleSubscribe(plan)}
+                disabled={!plan.stripe_price_id} // Deshabilitar si no hay stripe_price_id (ej. plan gratuito no gestionado por Stripe checkout)
+                className={`w-full py-2.5 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white
+                            ${!plan.stripe_price_id ? 'bg-n8n-button-hover cursor-not-allowed' : 'bg-n8n-accent hover:bg-n8n-accent-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-n8n-surface focus:ring-n8n-accent'}
+                            disabled:opacity-70`}
+              >
+                {plan.stripe_price_id ? (plan.price === 0 ? 'Get Started' : 'Subscribe') : 'Details'}
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/my-app/src/app/signup/page.tsx
+++ b/my-app/src/app/signup/page.tsx
@@ -73,12 +73,12 @@ export default function SignUpPage() {
 
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-900 text-white">
-      <div className="w-full max-w-md p-8 space-y-6 bg-gray-800 rounded-lg shadow-lg">
-        <h1 className="text-3xl font-bold text-center text-sky-400">Create Account</h1>
+    <div className="flex min-h-screen flex-col items-center justify-center bg-n8n-dark font-sans">
+      <div className="w-full max-w-md p-8 space-y-6 bg-n8n-surface rounded-lg shadow-xl">
+        <h1 className="text-3xl font-bold text-center text-n8n-accent">Create Account</h1>
         <form onSubmit={handleSignUp} className="space-y-6">
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-300">
+            <label htmlFor="email" className="block text-sm font-medium text-n8n-text-secondary">
               Email address
             </label>
             <input
@@ -89,13 +89,13 @@ export default function SignUpPage() {
               required
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-sky-500 focus:border-sky-500 sm:text-sm"
+              className="mt-1 block w-full px-3 py-2 bg-n8n-dark border border-n8n-border rounded-md shadow-sm placeholder-n8n-text-secondary focus:outline-none focus:ring-n8n-accent focus:border-n8n-accent sm:text-sm text-n8n-text-primary"
               placeholder="you@example.com"
             />
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-300">
+            <label htmlFor="password" className="block text-sm font-medium text-n8n-text-secondary">
               Password
             </label>
             <input
@@ -106,13 +106,13 @@ export default function SignUpPage() {
               required
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-sky-500 focus:border-sky-500 sm:text-sm"
+              className="mt-1 block w-full px-3 py-2 bg-n8n-dark border border-n8n-border rounded-md shadow-sm placeholder-n8n-text-secondary focus:outline-none focus:ring-n8n-accent focus:border-n8n-accent sm:text-sm text-n8n-text-primary"
               placeholder="••••••••"
             />
           </div>
 
           <div>
-            <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-300">
+            <label htmlFor="confirmPassword" className="block text-sm font-medium text-n8n-text-secondary">
               Confirm Password
             </label>
             <input
@@ -123,38 +123,38 @@ export default function SignUpPage() {
               required
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
-              className="mt-1 block w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-sky-500 focus:border-sky-500 sm:text-sm"
+              className="mt-1 block w-full px-3 py-2 bg-n8n-dark border border-n8n-border rounded-md shadow-sm placeholder-n8n-text-secondary focus:outline-none focus:ring-n8n-accent focus:border-n8n-accent sm:text-sm text-n8n-text-primary"
               placeholder="••••••••"
             />
           </div>
 
-          {error && <p className="text-sm text-red-400">{error}</p>}
-          {message && <p className="text-sm text-green-400">{message}</p>}
+          {error && <p className="text-sm text-n8n-error">{error}</p>}
+          {message && <p className="text-sm text-n8n-success">{message}</p>}
 
           <div>
             <button
               type="submit"
               disabled={isSubmitting}
-              className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-sky-600 hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-sky-500 disabled:opacity-50"
+              className="w-full flex justify-center py-2.5 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-n8n-accent hover:bg-n8n-accent-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-n8n-surface focus:ring-n8n-accent disabled:opacity-60 disabled:cursor-not-allowed"
             >
               {isSubmitting ? 'Signing Up...' : 'Sign Up'}
             </button>
           </div>
         </form>
 
-        <div className="relative my-4">
+        <div className="relative my-6">
           <div className="absolute inset-0 flex items-center">
-            <div className="w-full border-t border-gray-600" />
+            <div className="w-full border-t border-n8n-border" />
           </div>
           <div className="relative flex justify-center text-sm">
-            <span className="px-2 bg-gray-800 text-gray-400">Or sign up with</span>
+            <span className="px-3 bg-n8n-surface text-n8n-text-secondary">Or sign up with</span>
           </div>
         </div>
         <div>
           <button
             onClick={handleGitHubSignUp}
             disabled={isSubmitting}
-            className="w-full flex items-center justify-center py-2 px-4 border border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-300 bg-gray-700 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-sky-500 disabled:opacity-50"
+            className="w-full flex items-center justify-center py-2.5 px-4 border border-n8n-border rounded-md shadow-sm text-sm font-medium text-n8n-text-primary bg-n8n-button hover:bg-n8n-button-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-n8n-surface focus:ring-n8n-accent disabled:opacity-60 disabled:cursor-not-allowed"
           >
              <svg className="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
               <path fillRule="evenodd" d="M10 0C4.477 0 0 4.477 0 10c0 4.418 2.865 8.166 6.839 9.489.5.092.682-.217.682-.483 0-.237-.009-.868-.013-1.703-2.782.602-3.369-1.343-3.369-1.343-.455-1.158-1.11-1.465-1.11-1.465-.909-.62.069-.608.069-.608 1.004.074 1.532 1.03 1.532 1.03.891 1.529 2.341 1.087 2.91.832.091-.647.349-1.086.635-1.337-2.22-.251-4.555-1.111-4.555-4.943 0-1.091.39-1.984 1.03-2.682-.103-.252-.447-1.27.098-2.646 0 0 .84-.269 2.75 1.025A9.548 9.548 0 0110 5.425c.854 0 1.708.115 2.504.336 1.909-1.294 2.748-1.025 2.748-1.025.547 1.376.203 2.394.1 2.646.64.698 1.027 1.59 1.027 2.682 0 3.842-2.338 4.687-4.565 4.935.358.307.679.917.679 1.85 0 1.333-.012 2.407-.012 2.734 0 .268.18.578.688.48C17.138 18.163 20 14.417 20 10c0-5.523-4.477-10-10-10z" clipRule="evenodd" />
@@ -163,9 +163,9 @@ export default function SignUpPage() {
           </button>
         </div>
 
-        <p className="mt-6 text-center text-sm text-gray-400">
+        <p className="mt-8 text-center text-sm text-n8n-text-secondary">
           Already have an account?{' '}
-          <a href="/login" className="font-medium text-sky-400 hover:text-sky-300">
+          <a href="/login" className="font-medium text-n8n-accent hover:text-n8n-accent-hover">
             Sign In
           </a>
         </p>

--- a/my-app/supabase_migrations/001_create_plans_and_subscriptions_tables.sql
+++ b/my-app/supabase_migrations/001_create_plans_and_subscriptions_tables.sql
@@ -1,0 +1,133 @@
+-- Crear la tabla de planes (plans)
+CREATE TABLE IF NOT EXISTS plans (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    stripe_price_id TEXT UNIQUE, -- ID del precio en Stripe, puede ser nulo si el plan no está en Stripe (ej. plan gratuito gestionado localmente)
+    price NUMERIC(10, 2) NOT NULL DEFAULT 0.00,
+    currency TEXT NOT NULL DEFAULT 'usd',
+    interval TEXT, -- ej: 'month', 'year', NULL para planes gratuitos o de pago único no recurrente
+    description TEXT,
+    features JSONB, -- ej: '["Feature 1", "Feature 2"]'
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+COMMENT ON COLUMN plans.stripe_price_id IS 'ID del precio correspondiente en Stripe';
+COMMENT ON COLUMN plans.interval IS 'Frecuencia de facturación: month, year. NULL si no es recurrente.';
+COMMENT ON COLUMN plans.features IS 'Lista de características incluidas en el plan.';
+
+-- Crear la tabla de suscripciones (subscriptions)
+CREATE TABLE IF NOT EXISTS subscriptions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    plan_id UUID NOT NULL REFERENCES plans(id) ON DELETE RESTRICT,
+    stripe_subscription_id TEXT UNIQUE, -- ID de la suscripción en Stripe, puede ser nulo para planes gratuitos
+    stripe_customer_id TEXT NOT NULL, -- Todos los usuarios con suscripción (incluso gratuita si se gestiona pago futuro) deberían tener un customer_id
+    status TEXT NOT NULL, -- ej: 'active', 'trialing', 'past_due', 'canceled', 'unpaid', 'incomplete', 'incomplete_expired', 'paused'
+    current_period_start TIMESTAMP WITH TIME ZONE,
+    current_period_end TIMESTAMP WITH TIME ZONE,
+    cancel_at_period_end BOOLEAN DEFAULT FALSE,
+    canceled_at TIMESTAMP WITH TIME ZONE,
+    ended_at TIMESTAMP WITH TIME ZONE,
+    trial_start TIMESTAMP WITH TIME ZONE,
+    trial_end TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
+);
+
+COMMENT ON TABLE subscriptions IS 'Almacena las suscripciones de los usuarios a los planes.';
+COMMENT ON COLUMN subscriptions.user_id IS 'Referencia al usuario en auth.users.';
+COMMENT ON COLUMN subscriptions.plan_id IS 'Referencia al plan suscrito en la tabla plans.';
+COMMENT ON COLUMN subscriptions.stripe_subscription_id IS 'ID de la suscripción en Stripe. Nulo si es un plan gratuito no gestionado por Stripe.';
+COMMENT ON COLUMN subscriptions.stripe_customer_id IS 'ID del cliente en Stripe.';
+COMMENT ON COLUMN subscriptions.status IS 'Estado actual de la suscripción (ej: active, trialing, canceled).';
+COMMENT ON COLUMN subscriptions.current_period_start IS 'Inicio del período de facturación actual.';
+COMMENT ON COLUMN subscriptions.current_period_end IS 'Fin del período de facturación actual.';
+COMMENT ON COLUMN subscriptions.cancel_at_period_end IS 'Indica si la suscripción se cancelará al final del período actual.';
+
+-- Crear índices para mejorar el rendimiento de las consultas comunes
+CREATE INDEX IF NOT EXISTS idx_subscriptions_user_id ON subscriptions(user_id);
+CREATE INDEX IF NOT EXISTS idx_subscriptions_stripe_subscription_id ON subscriptions(stripe_subscription_id);
+CREATE INDEX IF NOT EXISTS idx_subscriptions_stripe_customer_id ON subscriptions(stripe_customer_id);
+CREATE INDEX IF NOT EXISTS idx_plans_active ON plans(active);
+
+-- (Opcional) Habilitar RLS (Row Level Security) si aún no está habilitado para estas tablas
+-- Se recomienda configurar políticas RLS específicas después de la creación de las tablas.
+-- ALTER TABLE plans ENABLE ROW LEVEL SECURITY;
+-- ALTER TABLE subscriptions ENABLE ROW LEVEL SECURITY;
+
+-- Ejemplo de cómo insertar un plan gratuito y uno premium (esto se haría desde la app o seed data, no aquí directamente en migración productiva sinó como setup inicial)
+/*
+INSERT INTO plans (name, price, currency, interval, features, active, stripe_price_id) VALUES
+('Gratuito', 0.00, 'usd', NULL, '["Análisis IA Básico (limitado)", "Seguimiento de hasta 3 activos"]', TRUE, NULL),
+('Premium Mensual', 10.00, 'usd', 'month', '["Análisis IA Completo", "Seguimiento ilimitado de activos", "Historial de pronósticos extendido"]', TRUE, 'price_xxxxxxxxxxxxxx');
+*/
+
+-- Nota sobre stripe_price_id y stripe_subscription_id:
+-- Para planes gratuitos que no se gestionan a través de Stripe, stripe_price_id y stripe_subscription_id pueden ser NULL.
+-- Si un usuario se suscribe a un plan gratuito y luego actualiza a uno de pago, se creará/actualizará el stripe_customer_id y stripe_subscription_id.
+-- stripe_customer_id es importante mantenerlo incluso para usuarios gratuitos si se planea que puedan actualizar a planes de pago,
+-- ya que Stripe lo usa para vincular suscripciones y métodos de pago a un cliente.
+-- Considerar si todos los usuarios (incluso los gratuitos) deben tener un stripe_customer_id creado al registrarse.
+-- Esto simplifica la actualización a un plan de pago. Si no, se crearía al iniciar el primer checkout de pago.
+
+-- Función para actualizar el campo updated_at automáticamente
+CREATE OR REPLACE FUNCTION trigger_set_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = timezone('utc'::text, now());
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Aplicar el trigger a las tablas
+CREATE TRIGGER set_timestamp_plans
+BEFORE UPDATE ON plans
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_timestamp();
+
+CREATE TRIGGER set_timestamp_subscriptions
+BEFORE UPDATE ON subscriptions
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_timestamp();
+
+-- Añadir una columna para el rol del usuario, que podría estar vinculada a su plan/suscripción
+-- Esto es un ejemplo y podría gestionarse de otras maneras.
+-- ALTER TABLE public.users ADD COLUMN IF NOT EXISTS app_role TEXT DEFAULT 'free_user';
+-- Podrías tener una función que actualice este rol basado en la suscripción activa.
+
+-- Considerar políticas RLS para proteger los datos de los usuarios
+-- Ejemplo de política para la tabla de suscripciones:
+-- Permitir a los usuarios ver solo sus propias suscripciones.
+/*
+CREATE POLICY "Allow individual user access to their subscriptions"
+ON public.subscriptions
+FOR SELECT
+USING (auth.uid() = user_id);
+
+CREATE POLICY "Allow user to insert their own subscription"
+ON public.subscriptions
+FOR INSERT
+WITH CHECK (auth.uid() = user_id);
+
+-- Para la tabla de planes, generalmente todos los usuarios autenticados podrían leer los planes activos.
+CREATE POLICY "Allow authenticated users to read active plans"
+ON public.plans
+FOR SELECT
+USING (active = TRUE AND auth.role() = 'authenticated');
+*/
+-- Las políticas RLS exactas dependerán de tus necesidades específicas de seguridad y acceso.
+-- Es crucial definir estas políticas cuidadosamente.
+-- Por ahora, las políticas están comentadas. Deberás habilitarlas y configurarlas según sea necesario.
+-- Recuerda que para que RLS funcione, debe estar habilitado en la tabla:
+-- ALTER TABLE public.plans ENABLE ROW LEVEL SECURITY;
+-- ALTER TABLE public.subscriptions ENABLE ROW LEVEL SECURITY;
+
+-- También, asegúrate de que el usuario/rol que usa Next.js para acceder a Supabase tenga los permisos necesarios (SELECT, INSERT, UPDATE, DELETE) sobre estas tablas.
+-- Por defecto, el rol `anon` (anónimo) y `authenticated` tienen ciertos permisos.
+-- Puedes ajustar esto en el Dashboard de Supabase > Roles.
+-- Para las operaciones de escritura (INSERT, UPDATE) que involucren datos de Stripe, estas generalmente se harán desde funciones seguras del servidor (Edge Functions)
+-- que interactúan con la API de Stripe y luego actualizan tu base de datos, en lugar de directamente desde el cliente.
+-- Las lecturas de planes y el estado de suscripción del usuario actual sí pueden hacerse desde el cliente con RLS adecuado.
+-- Fin del script

--- a/my-app/supabase_migrations/002_adapt_tables_for_multiple_gateways.sql
+++ b/my-app/supabase_migrations/002_adapt_tables_for_multiple_gateways.sql
@@ -1,0 +1,86 @@
+-- Adaptar la tabla plans para múltiples pasarelas
+ALTER TABLE public.plans
+ADD COLUMN gateway TEXT NOT NULL DEFAULT 'stripe';
+
+-- Renombrar stripe_price_id a gateway_plan_id
+-- Primero, eliminamos la restricción UNIQUE existente en stripe_price_id si existe
+-- El nombre de la restricción puede variar, necesitas verificarlo en tu DDL o dashboard de Supabase.
+-- Comúnmente es plans_stripe_price_id_key. Si es diferente, ajusta el script.
+DO $$
+BEGIN
+   IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'plans_stripe_price_id_key' AND conrelid = 'public.plans'::regclass) THEN
+      ALTER TABLE public.plans DROP CONSTRAINT plans_stripe_price_id_key;
+   END IF;
+END $$;
+
+ALTER TABLE public.plans
+RENAME COLUMN stripe_price_id TO gateway_plan_id;
+
+-- Añadir una nueva restricción UNIQUE para la combinación de gateway y gateway_plan_id (si gateway_plan_id no es NULL)
+-- No podemos tener una restricción UNIQUE directa que ignore NULLs de esta manera en todos los PostgreSQL.
+-- Una forma es crear un índice único condicional.
+CREATE UNIQUE INDEX IF NOT EXISTS unique_gateway_plan_id_not_null
+ON public.plans (gateway, gateway_plan_id)
+WHERE gateway_plan_id IS NOT NULL;
+
+-- Comentar la columna gateway
+COMMENT ON COLUMN public.plans.gateway IS 'Pasarela de pago (ej: stripe, mercadopago)';
+COMMENT ON COLUMN public.plans.gateway_plan_id IS 'ID del plan/precio en la pasarela de pago correspondiente';
+
+
+-- Adaptar la tabla subscriptions para múltiples pasarelas
+ALTER TABLE public.subscriptions
+ADD COLUMN gateway TEXT NOT NULL DEFAULT 'stripe';
+
+-- Renombrar stripe_subscription_id a gateway_subscription_id
+DO $$
+BEGIN
+   IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'subscriptions_stripe_subscription_id_key' AND conrelid = 'public.subscriptions'::regclass) THEN
+      ALTER TABLE public.subscriptions DROP CONSTRAINT subscriptions_stripe_subscription_id_key;
+   END IF;
+END $$;
+ALTER TABLE public.subscriptions
+RENAME COLUMN stripe_subscription_id TO gateway_subscription_id;
+
+-- Renombrar stripe_customer_id a gateway_customer_id
+-- No se espera una restricción UNIQUE directa solo en stripe_customer_id, pero si la hubiera, habría que dropearla.
+ALTER TABLE public.subscriptions
+RENAME COLUMN stripe_customer_id TO gateway_customer_id;
+
+-- Añadir una nueva restricción UNIQUE para la combinación de gateway y gateway_subscription_id (si gateway_subscription_id no es NULL)
+CREATE UNIQUE INDEX IF NOT EXISTS unique_gateway_subscription_id_not_null
+ON public.subscriptions (gateway, gateway_subscription_id)
+WHERE gateway_subscription_id IS NOT NULL;
+
+-- Considerar una restricción para asegurar que un usuario no tenga múltiples gateway_customer_id para la misma pasarela.
+-- Esto podría ser más complejo si un usuario puede tener múltiples suscripciones con la misma pasarela pero diferentes customer IDs (poco común).
+-- Por ahora, nos enfocamos en la unicidad de la suscripción.
+-- Podríamos añadir un índice único en (user_id, gateway) a una tabla de 'user_payment_profiles' si la creamos.
+
+-- Comentar las nuevas columnas
+COMMENT ON COLUMN public.subscriptions.gateway IS 'Pasarela de pago (ej: stripe, mercadopago)';
+COMMENT ON COLUMN public.subscriptions.gateway_subscription_id IS 'ID de la suscripción en la pasarela de pago correspondiente';
+COMMENT ON COLUMN public.subscriptions.gateway_customer_id IS 'ID del cliente en la pasarela de pago correspondiente';
+
+-- Actualizar los triggers para que sigan funcionando (no necesitan cambios ya que solo actualizan updated_at)
+-- No es necesario recrear los triggers set_timestamp_plans y set_timestamp_subscriptions.
+
+-- Nota:
+-- Después de ejecutar este script, los datos existentes en las columnas renombradas se conservarán.
+-- Las nuevas columnas 'gateway' tendrán el valor por defecto 'stripe'.
+-- Deberás actualizar manualmente los registros de planes existentes para reflejar la pasarela correcta si ya tienes datos de Mercado Pago
+-- o si algunos planes de Stripe ya estaban destinados a ser solo de Stripe.
+-- Los nuevos índices UNIQUE condicionales aseguran la integridad de los datos para los IDs de pasarela.
+-- Si los nombres de las restricciones UNIQUE originales eran diferentes, este script podría necesitar ajustes.
+-- Puedes encontrar los nombres exactos en el panel de Supabase o inspeccionando la DDL de la tabla.
+-- Por ejemplo, para encontrar el nombre de la restricción de unicidad en `stripe_price_id` en la tabla `plans`:
+/*
+SELECT conname
+FROM pg_constraint
+WHERE conrelid = 'public.plans'::regclass
+  AND contype = 'u'
+  AND CASE WHEN (SELECT COUNT(*) FROM unnest(conkey) elem WHERE elem = (SELECT attnum FROM pg_attribute WHERE attrelid = 'public.plans'::regclass AND attname = 'stripe_price_id')) > 0 THEN TRUE ELSE FALSE END;
+*/
+-- Y similar para `subscriptions_stripe_subscription_id_key`.
+-- El script intenta eliminar las restricciones con nombres comunes, pero es mejor verificar.
+-- Fin del script de migración 002

--- a/my-app/tailwind.config.ts
+++ b/my-app/tailwind.config.ts
@@ -8,32 +8,31 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['var(--font-inter)', 'sans-serif'], // Set Inter as the default sans-serif font
+      },
+      colors: {
+        // Define a color palette inspired by n8n.io's sober and professional look
+        // These are example colors, you might need to adjust them by inspecting n8n.io
+        'n8n-dark': '#0D0D0D', // Very dark (almost black) for backgrounds
+        'n8n-surface': '#1A1A1A', // Slightly lighter dark for cards, input fields
+        'n8n-border': '#333333', // For borders
+        'n8n-text-primary': '#E0E0E0', // Light gray for primary text
+        'n8n-text-secondary': '#A0A0A0', // Medium gray for secondary text
+        'n8n-accent': '#569CD6', // A calm blue for accents, links, and highlights
+        'n8n-accent-hover': '#6BAEFD', // Lighter blue for hover states
+        'n8n-button': '#333333',
+        'n8n-button-hover': '#454545',
+        // You can add more specific colors as needed, e.g., for success, error, warning states
+        'n8n-success': '#38A169', // Green
+        'n8n-error': '#E53E3E',   // Red
+        'n8n-warning': '#DD6B20', // Orange
+      },
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic":
           "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
       },
-      // You can extend your theme here (e.g., custom colors, fonts)
-      colors: {
-        sky: {
-          // Example custom shades for sky, matching the auth forms
-          300: '#7dd3fc',
-          400: '#38bdf8',
-          500: '#0ea5e9',
-          600: '#0284c7',
-          700: '#0369a1',
-        },
-        gray: {
-          // Example custom shades for gray, matching the auth forms
-          300: '#d1d5db',
-          400: '#9ca3af',
-          500: '#6b7280',
-          600: '#4b5563',
-          700: '#374151',
-          800: '#1f2937',
-          900: '#111827',
-        }
-      }
     },
   },
   plugins: [],


### PR DESCRIPTION
- Add SQL migration to adapt 'plans' and 'subscriptions' tables for multiple payment gateways (Stripe, MercadoPago).
- Rename Stripe-specific ID columns to generic 'gateway_...' columns.
- Add 'gateway' column to distinguish between providers.
- Create initial API endpoint for Stripe checkout session creation (/api/stripe/create-checkout-session).
- Create initial API endpoint for Stripe webhook handling (/api/stripe/webhook).
- Add initial pricing page (/pricing) to display plans from DB and initiate Stripe checkout.
- Add IA analysis page (/ia-analysis) with form and display for n8n webhook interaction.
- Update UI theme to a more sober design inspired by n8n.io.
- Install Stripe Node.js library.